### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/749/153/101749153.geojson
+++ b/data/101/749/153/101749153.geojson
@@ -374,6 +374,9 @@
         "wd:id":"Q27116"
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea15a31a0552c426ff0728b04e454a83",
     "wof:hierarchy":[
         {
@@ -388,7 +391,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581583,
+    "wof:lastmodified":1582332404,
     "wof:name":"Vejle",
     "wof:parent_id":1159297913,
     "wof:placetype":"locality",

--- a/data/101/805/677/101805677.geojson
+++ b/data/101/805/677/101805677.geojson
@@ -167,6 +167,9 @@
         "qs_pg:id":901087
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a4525efaadcfd2cdb1b867f1054ea74",
     "wof:hierarchy":[
         {
@@ -178,7 +181,7 @@
         }
     ],
     "wof:id":101805677,
-    "wof:lastmodified":1566581583,
+    "wof:lastmodified":1582332404,
     "wof:name":"Lemvig",
     "wof:parent_id":1159297919,
     "wof:placetype":"locality",

--- a/data/101/817/291/101817291.geojson
+++ b/data/101/817/291/101817291.geojson
@@ -122,6 +122,9 @@
         "wk:page":"Ebeltoft"
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c8277110f28347b5f8fbbc7d43836d1a",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101817291,
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1582332404,
     "wof:name":"Ebeltoft",
     "wof:parent_id":1159297809,
     "wof:placetype":"locality",

--- a/data/857/941/41/85794141.geojson
+++ b/data/857/941/41/85794141.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":222243
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b95c5d2772267491c9dc43e6a79d6887",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1582332404,
     "wof:name":"Boldesager",
     "wof:parent_id":101749155,
     "wof:placetype":"neighbourhood",

--- a/data/857/941/45/85794145.geojson
+++ b/data/857/941/45/85794145.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":402367
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"21a1aebb025b799c80f2cebe5d22e58d",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1582332404,
     "wof:name":"S\u00f8nder Varde",
     "wof:parent_id":101805511,
     "wof:placetype":"neighbourhood",

--- a/data/858/663/67/85866367.geojson
+++ b/data/858/663/67/85866367.geojson
@@ -84,6 +84,10 @@
         "qs_pg:id":891802
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"26f89f3ea460e5f9afb36fb88d39892c",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1582332404,
     "wof:name":"Esbjerg O",
     "wof:parent_id":101749155,
     "wof:placetype":"neighbourhood",

--- a/data/858/988/01/85898801.geojson
+++ b/data/858/988/01/85898801.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":240997
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e58846f4c614040eb445d3c884c048c2",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581582,
+    "wof:lastmodified":1582332404,
     "wof:name":"Nyborg Strand",
     "wof:parent_id":101818223,
     "wof:placetype":"neighbourhood",

--- a/data/859/079/15/85907915.geojson
+++ b/data/859/079/15/85907915.geojson
@@ -87,6 +87,10 @@
         "qs_pg:id":1115818
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea3a3bc6ce82a9cef4146d31bdd1b4c6",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332404,
     "wof:name":"Aalborg SO",
     "wof:parent_id":101749169,
     "wof:placetype":"neighbourhood",

--- a/data/859/079/27/85907927.geojson
+++ b/data/859/079/27/85907927.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":977344
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"db89678794ad77966b420a24b63dd04a",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332404,
     "wof:name":"Odense C",
     "wof:parent_id":101749151,
     "wof:placetype":"neighbourhood",

--- a/data/859/079/29/85907929.geojson
+++ b/data/859/079/29/85907929.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1263575
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"900ae4e8148360216a153687bd7b707a",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332404,
     "wof:name":"Odense M",
     "wof:parent_id":101749151,
     "wof:placetype":"neighbourhood",

--- a/data/859/079/35/85907935.geojson
+++ b/data/859/079/35/85907935.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":467163
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d818998dd0129dbd3966da4f7bd82a69",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332403,
     "wof:name":"Odense NV",
     "wof:parent_id":101749151,
     "wof:placetype":"neighbourhood",

--- a/data/859/346/25/85934625.geojson
+++ b/data/859/346/25/85934625.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1347085
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec93364f2ae7418615fb0ecf50f26e21",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332404,
     "wof:name":"Randers SV",
     "wof:parent_id":101749161,
     "wof:placetype":"neighbourhood",

--- a/data/859/346/29/85934629.geojson
+++ b/data/859/346/29/85934629.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1090268
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f5d8e03be7f14af3a281cb0a2fba029d",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332404,
     "wof:name":"Randers NO",
     "wof:parent_id":101749161,
     "wof:placetype":"neighbourhood",

--- a/data/859/346/33/85934633.geojson
+++ b/data/859/346/33/85934633.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":383676
     },
     "wof:country":"DN",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd2c5160a4d1b16deb11b725cb3c29ba",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "dan"
     ],
-    "wof:lastmodified":1566581581,
+    "wof:lastmodified":1582332404,
     "wof:name":"Randers NV",
     "wof:parent_id":101749161,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.